### PR TITLE
fix webpack error for camelCase,localIndentName

### DIFF
--- a/webpack.config.renderer.dev.js
+++ b/webpack.config.renderer.dev.js
@@ -128,11 +128,12 @@ export default merge.smart(baseConfig, {
           {
             loader: 'css-loader',
             options: {
-              modules: true,
               sourceMap: true,
-              camelCase: true,
+              localsConvention: 'camelCase',
               importLoaders: 1,
-              localIdentName: '[name]__[local]__[hash:base64:5]'
+              modules: {
+                localIdentName: '[name]__[local]__[hash:base64:5]'
+              }
             }
           }
         ]
@@ -165,10 +166,11 @@ export default merge.smart(baseConfig, {
           {
             loader: 'css-loader',
             options: {
-              modules: true,
               sourceMap: true,
               importLoaders: 1,
-              localIdentName: '[name]__[local]__[hash:base64:5]'
+              modules: {
+                localIdentName: '[name]__[local]__[hash:base64:5]'
+              }
             }
           },
           {

--- a/webpack.config.renderer.prod.js
+++ b/webpack.config.renderer.prod.js
@@ -67,11 +67,12 @@ export default merge.smart(baseConfig, {
           use: {
             loader: 'css-loader',
             options: {
-              modules: true,
               minimize: true,
-              camelCase: true,
+              localconvetion: 'camelCase',
               importLoaders: 1,
-              localIdentName: '[name]__[local]__[hash:base64:5]'
+              modules: {
+                localIdentName: '[name]__[local]__[hash:base64:5]'
+              }
             }
           }
         })
@@ -102,10 +103,11 @@ export default merge.smart(baseConfig, {
             {
               loader: 'css-loader',
               options: {
-                modules: true,
                 minimize: true,
                 importLoaders: 1,
-                localIdentName: '[name]__[local]__[hash:base64:5]'
+                modules: {
+                  localIdentName: '[name]__[local]__[hash:base64:5]'
+                }
               }
             },
             {


### PR DESCRIPTION
the pull request fix this error when run yarn dev
```
ERROR in ./app/assets/css/AddRowIcon.css (./node_modules/css-loader/dist/cjs.js??ref--7-1!./app/assets/css/AddRowIcon.css)                               
Module build failed (from ./node_modules/css-loader/dist/cjs.js):
ValidationError: Invalid options object. CSS Loader has been initialised using an options object that does not match the API schema.                     
 - **options has an unknown property 'localIdentName'.** These properties are valid:
```