### PR TITLE
CheckUpdate only for darwin and win32

### DIFF
--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -121,7 +121,8 @@ autoUpdater.on('update-downloaded', () => {
 });
 
 app.on('ready', () => {
-  autoUpdater.checkForUpdates();
+  if (process.platform === 'darwin' || process.platform === 'win32')
+    autoUpdater.checkForUpdates();
 
   ipcMain.on('openExportWindow', () => {
     const win = new BrowserWindow({


### PR DESCRIPTION
Check for update only for darwin and win32 platform. Linux user can't use it and use the system package manager (apt, yum, etc...)